### PR TITLE
Update MessageReplaySubscriber.c

### DIFF
--- a/src/intro/MessageReplaySubscriber.c
+++ b/src/intro/MessageReplaySubscriber.c
@@ -2,7 +2,7 @@
  */
 
 /*
- *  Copyright 2012-2019 Solace Corporation. All rights reserved.
+ *  Copyright 2019 Solace Corporation. All rights reserved.
  *
  *  http://www.solace.com
  *
@@ -16,15 +16,32 @@
  *
  *  MessageReplaySubscriber
  *
- *  This is a modification of the QueueSubscriber example for message replay.
+ *  This sample demonstrates the message replay feature in the Solace Message 
+ *  Router.  
  *
- *  First, when the flow connects, all messages are requested from the replay log.
- *  Comments show how to request the replay log from a specific start time.
+ *******************************************************************************
+ *  SETUP
  *
- *  Second, the flow event handler is extended for the possibility
- *  of a replay start event. This means the router initiated a replay,
- *  and the application must destroy and re-create the flow
- *  to receive the replayed messages.
+ *  Before running this sample be sure that message-replay is enabled in the VPN
+ *  usd for the test. 
+ *  Also messages must have been published to the replay-log for the queue that is 
+ *  used.  The QueuePublisher sample can be used to create and publish messages to 
+ *  the queue.  The QueueSubscriber sample can be used to drain the queue, so that 
+ *  replay is performed on an empty queue and observed by this sample.
+ ********************************************************************************
+ *
+ ********************************************************************************
+ *  TES
+ *
+ *  First, a client initiated replay is started when the flow connects.  All 
+ *  messages are requested from the replay log. Comments also explain  how to
+ *  request the replay log from a specific start time.
+ *
+ *  Second, the application waits for a CLI/Message-Router initiated replay.
+ *  The flow event handler monitors for a replay start event. When the Message-Router
+ *  initiates a replay, the flow will see a DOWN_ERROR event with cause
+ *  'Replay Started'.  This means an operator has initiated a replay, and the
+ *  application must destroy and re-create the flow  to receive the replayed messages.
  */
 
 #include "os.h"
@@ -38,7 +55,8 @@ static int msgCount = 0;
 /*****************************************************************************
  * sessionMessageReceiveCallback
  *
- * The message receive callback is mandatory for session creation.
+ * The message receive callback is mandatory for session creation. This
+ * callback silently discards all received messages.
  *****************************************************************************/
 static          solClient_rxMsgCallback_returnCode_t
 sessionMessageReceiveCallback ( solClient_opaqueSession_pt opaqueSession_p, solClient_opaqueMsg_pt msg_p, void *user_p )
@@ -49,7 +67,8 @@ sessionMessageReceiveCallback ( solClient_opaqueSession_pt opaqueSession_p, solC
 /*****************************************************************************
  * sessionEventCallback
  *
- * The event callback function is mandatory for session creation.
+ * The event callback function is mandatory for session creation. This callback
+ * ignores all session events.
  *****************************************************************************/
 void
 sessionEventCallback ( solClient_opaqueSession_pt opaqueSession_p,
@@ -60,18 +79,22 @@ sessionEventCallback ( solClient_opaqueSession_pt opaqueSession_p,
 /*****************************************************************************
  * flowEventCallback
  *
- * The event callback function is mandatory for flow creation.
+ * The event callback function is mandatory for flow creation.  Monitor for
+ * SOLCLIENT_FLOW_EVENT_DOWN_ERROR. When see, save the error information for
+ * processing by the main thread.
  *****************************************************************************/
 static void
 flowEventCallback ( solClient_opaqueFlow_pt opaqueFlow_p, solClient_flow_eventCallbackInfo_pt eventInfo_p, void *user_p )
 {
     // The flow can not be destroyed and re-created from this callback,
     // so the errorInfo is only saved instead, and processed on the main loop.
-    solClient_errorInfo_pt flowErrorInfo_p = (solClient_errorInfo_pt) user_p;
-    solClient_errorInfo_pt errorInfo_p = solClient_getLastErrorInfo();
-    flowErrorInfo_p->responseCode = errorInfo_p->responseCode;
-    flowErrorInfo_p->subCode = errorInfo_p->subCode;
-    strncpy(errorInfo_p->errorStr, flowErrorInfo_p->errorStr, sizeof(flowErrorInfo_p->errorStr));
+    if ( SOLCLIENT_FLOW_EVENT_DOWN_ERROR == eventInfo_p->flowEvent ) {
+        solClient_errorInfo_pt flowErrorInfo_p = (solClient_errorInfo_pt) user_p;
+        solClient_errorInfo_pt errorInfo_p = solClient_getLastErrorInfo();
+        flowErrorInfo_p->responseCode = errorInfo_p->responseCode;
+        flowErrorInfo_p->subCode = errorInfo_p->subCode;
+        strncpy(errorInfo_p->errorStr, flowErrorInfo_p->errorStr, sizeof(flowErrorInfo_p->errorStr));
+    }
 
     printf ( "flowEventCallbackFunc() called - %s; subCode: %s, responseCode: %d, reason: \"%s\"\n",
             solClient_flow_eventToString ( eventInfo_p->flowEvent ),
@@ -124,18 +147,16 @@ main ( int argc, char *argv[] )
     solClient_flow_createFuncInfo_t flowFuncInfo = SOLCLIENT_FLOW_CREATEFUNC_INITIALIZER;
 
     /* Session Properties */
-    const char     *sessionProps[20] = {0, };
+    const char     *sessionProps[20] = {NULL};
     int             propIndex;
+    int             replayStartLocationIndex;
 
     /* Flow Properties */
-    const char     *flowProps[20] = {0, };
+    const char     *flowProps[20] = {NULL};
 
     /* Provision Properties */
-    const char     *provProps[20] = {0, };
+    const char     *provProps[20] = {NULL};
     int             provIndex;
-
-    /* Queue Network Name to be used with "solClient_session_endpointProvision()" */
-    char            qNN[80];
 
     if ( argc < 6 ) {
         printf ( "Usage: MessageReplaySubscriber <msg_backbone_ip:port> <vpn> <client-username> <password> <queue>\n" );
@@ -148,7 +169,6 @@ main ( int argc, char *argv[] )
 
     /* solClient needs to be initialized before any other API calls. */
     solClient_initialize ( SOLCLIENT_LOG_DEFAULT_FILTER, NULL );
-    //solClient_initialize ( SOLCLIENT_LOG_DEBUG, NULL );
 
     /*************************************************************************
      * CREATE A CONTEXT
@@ -225,10 +245,12 @@ main ( int argc, char *argv[] )
                                           session_p,
                                           SOLCLIENT_PROVISION_FLAGS_WAITFORCONFIRM|
                                           SOLCLIENT_PROVISION_FLAGS_IGNORE_EXIST_ERRORS,
-                                          NULL, qNN, sizeof ( qNN ) );
+                                          NULL, NULL, 0 );
 
     /*************************************************************************
      * Create a Flow
+     * On this flow request a replay of all messages that have ever been published
+     * to this queue name.
      *************************************************************************/
 
     /* Configure the Flow function information */
@@ -249,22 +271,37 @@ main ( int argc, char *argv[] )
 
     flowProps[propIndex++] = SOLCLIENT_FLOW_PROP_BIND_NAME;
     flowProps[propIndex++] = argv[5];
+    
+    /*
+     * Remember the replayStartLocation index for later, as we 
+     * need to modify or remove this property.
+     */
+    replayStartLocationIndex = propIndex;
 
     flowProps[propIndex++] = SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION;
-    flowProps[propIndex] = SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION_BEGINNING;
+    flowProps[propIndex++] = SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION_BEGINNING;
 
-    // Alternative replay start specifications:
-    //
-    // Seconds since UNIX epoch:
-    // flowProps[propIndex] = "DATE:1554331492";
-    //
-    // RFC3339 date without timezone:
-    // flowProps[propIndex] = "DATE:2019-04-03T18:48:00Z";
-    //
-    // RFC3339 date with timezone:
-    // flowProps[propIndex] = "DATE:2019-04-03T18:48:00Z-05:00";
+    /***************************************************************
+     * Alternative replay start specifications to try instead of 
+     * SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION_BEGINNING.
+     *
+     * Seconds since UNIX epoch:
+     * flowProps[propIndex] = "DATE:1554331492";
+     *
+     * RFC3339 UTC date with timezone offset 0:
+     * flowProps[propIndex] = "DATE:2019-04-03T18:48:00Z";
+     *
+     * RFC3339 date with timezone:
+     * flowProps[propIndex] = "DATE:2019-04-03T18:48:00Z-05:00";
+     **************************************************************/
+    
+    /**************************************************************
+     * NULL terminated the flow properties array
+     **************************************************************/
+    flowProps[propIndex++] = NULL;
+    flowPRops[propIndex] = NULL;
 
-    solClient_errorInfo_t flowErrorInfo = {0, 0, ""};
+    solClient_errorInfo_t flowErrorInfo = {SOLCLIENT_SUBCODE_OK, 0, ""};
     flowFuncInfo.eventInfo.user_p = &flowErrorInfo;
 
 
@@ -288,9 +325,9 @@ main ( int argc, char *argv[] )
     printf ( "Waiting for 10 messages......\n" );
     fflush ( stdout );
     while ( msgCount < 10 ) {
-        if (flowErrorInfo.subCode  != 0) {
+        if (flowErrorInfo.subCode  != SOLCLIENT_SUBCODE_OK) {
             if (flowErrorInfo.subCode == SOLCLIENT_SUBCODE_REPLAY_STARTED) {
-                printf ( "Router indicating replay, reconnecting flow to recieve messages.\n" );
+                printf ( "Router initiating replay, reconnecting flow to recieve messages.\n" );
                 flowErrorInfo.responseCode = 0;
                 flowErrorInfo.subCode = 0;
                 flowErrorInfo.errorStr[0] = '\0';
@@ -300,6 +337,19 @@ main ( int argc, char *argv[] )
                 // the second and consecutive times.
 
                 solClient_flow_destroy(&flow_p);
+                /*
+                 * Remove the REPLAU_START_LOCATION from the flow properties array
+                 * as it would override the operator initiated replay request.
+                 * NOTE: the REPLAY_START_LOCATION must be the last property 
+                 * for this to work.
+                 */
+                propIndex = replayStartLocationIndex;
+                /**************************************************************
+                 * NULL terminated the flow properties array
+                 **************************************************************/
+                flowProps[propIndex++] = NULL;
+                flowPRops[propIndex] = NULL;
+                   
                 rc = solClient_session_createFlow ( ( char ** ) flowProps,
                         session_p,
                         &flow_p, &flowFuncInfo, sizeof ( flowFuncInfo ) );
@@ -309,14 +359,6 @@ main ( int argc, char *argv[] )
                     printf ( "ErrorInfo subCode: %s, responseCode: %d, reason: \"%s\"\n", solClient_subCodeToString ( errorInfo_p->subCode ), errorInfo_p->responseCode, errorInfo_p->errorStr );
                     return -1;
                 }
-
-                // Alternatively, the application could reconnect the session instead,
-                // leaving the flow intact (relying on auto-rebind)
-                // and not receive the messages from the replay log repeatedly:
-
-                //solClient_session_disconnect ( session_p );
-                //solClient_session_connect ( session_p );
-
             } else if (flowErrorInfo.subCode == SOLCLIENT_SUBCODE_REPLAY_START_TIME_NOT_AVAILABLE) {
                 // This can only happen when the replay is requested from a specific start time,
                 // which is older than the replay log on the router.
@@ -325,7 +367,7 @@ main ( int argc, char *argv[] )
                 flowErrorInfo.subCode = 0;
                 flowErrorInfo.errorStr[0] = '\0';
 
-                flowProps[propIndex] = SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION_BEGINNING;
+                flowProps[replayStartLocationIndex + 1] = SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION_BEGINNING;
                 solClient_flow_destroy(&flow_p);
                 rc = solClient_session_createFlow ( ( char ** ) flowProps,
                         session_p,


### PR DESCRIPTION
I added more comments and the test setup and test itself. Also in the main.  Made the comment style consistent (all C not C++).  

If this is derived from QueuePublisher and QueueSubscriber then those samples need work too. For starter remove any reference to the deprecated QNN.

Other general style things,  pointers should be initialized to NULL not 0,  subCode should be initialized and compared to member of the enum (SOLCLIENT_SUBCODE_OK) not zero.